### PR TITLE
add backup server option for gluster::client_mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Attributes
     <td>Mount point to use for the Gluster volume</td>
     <td>None</td>
   </tr>
+  <tr>
+    <td><tt>['gluster']['client']['volumes'][VOLUME_NAME]['backup_server']</tt></td>
+    <td>String</td>
+    <td>Name of the backup volfile server to mount the client. When the first volfile server fails, then the server specified here is used as volfile server and is mounted by the client.</td>
+    <td>None</td>
+  </tr>
 </table>
 
 #### gluster::server

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,6 +4,6 @@ maintainer_email 'jared.king@biola.edu'
 license          'Apache 2.0'
 description      'Installs and configures Gluster servers and clients'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '2.1.0'
+version          '2.1.1'
 depends          'apt'
 depends          'yum', '>= 3.0.0'

--- a/recipes/client_mount.rb
+++ b/recipes/client_mount.rb
@@ -18,22 +18,28 @@
 #
 
 # Mount any configured volumes
-node["gluster"]['client']["volumes"].each do |volume_name, volume_values|
+node['gluster']['client']['volumes'].each do |volume_name, volume_values|
   if volume_values['server'].nil? || volume_values['mount_point'].nil?
-    Chef::Log.warn("Missing configuration for volume #{volume_name}. Skipping...")
+    Chef::Log.warn("No config for volume #{volume_name}. Skipping...")
     return
   else
+    # Define a backup server for this volume, if available
+    mount_options = 'defaults,_netdev'
+    unless volume_values['backup_server'].nil?
+      mount_options += ',backupvolfile-server=' + volume_values['backup_server']
+    end
+
     # Ensure the mount point exists
     directory volume_values['mount_point'] do
       recursive true
       action :create
     end
-    
+
     # Mount the partition and add to /etc/fstab
     mount volume_values['mount_point'] do
       device "#{volume_values['server']}:/#{volume_name}"
-      fstype "glusterfs"
-      options "defaults,_netdev"
+      fstype 'glusterfs'
+      options mount_options
       pass 0
       action [:mount, :enable]
     end


### PR DESCRIPTION
This patch makes use of the GlusterFS 'backupvolfile-server' mount option, if the ['gluster']['client']['volumes'][VOLUME_NAME]['backup_server'] is set. 