### PR TITLE
Allow to multiple backup servers when mounting a glusterfs volume

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Attributes
 Node attributes to specify volumes to mount. This has been deprecated in favor of using the 'gluster_mount' LWRP.
 
 - `node['gluster']['client']['volumes'][VOLUME_NAME]['server']` - server to connect to
-- `node['gluster']['client']['volumes'][VOLUME_NAME]['backup_server']` - name of the backup volfile server to mount the client. When the first volfile server fails, then the server specified here is used as volfile server and is mounted by the client.
+- `node['gluster']['client']['volumes'][VOLUME_NAME]['backup_server']` - name of the backup volfile server to mount the client. When the first volfile server fails, then the server specified here is used as volfile server and is mounted by the client. This can be a String or Array of Strings.
 - `node['gluster']['client']['volumes'][VOLUME_NAME]['mount_point']` - mount point to use for the Gluster volume
 
 ### gluster::server
@@ -44,6 +44,15 @@ Use the gluster_mount LWRP to mount volumes on clients:
 gluster_mount 'volume_name' do
   server 'gluster1.example.com'
   backup_server 'gluster2.example.com'
+  mount_point '/mnt/gluster/volume_name'
+  action [:mount, :enable]
+end
+```
+
+```ruby
+gluster_mount 'volume_name' do
+  server 'gluster1.example.com'
+  backup_server ['gluster2.example.com', 'gluster3.example.com']
   mount_point '/mnt/gluster/volume_name'
   action [:mount, :enable]
 end

--- a/providers/mount.rb
+++ b/providers/mount.rb
@@ -69,7 +69,12 @@ def mount_options
   # Define a backup server for this volume, if available
   options = 'defaults,_netdev'
   unless new_resource.backup_server.nil?
-    options += ',backupvolfile-server=' + new_resource.backup_server
+    case
+      when new_resource.backup_server.class == String
+        options += ',backupvolfile-server=' + new_resource.backup_server
+      when new_resource.backup_server.class == Array
+        options += ',backupvolfile-server=' + new_resource.backup_server.join(",backupvolfile-server=")
+    end
   end
   options
 end

--- a/resources/mount.rb
+++ b/resources/mount.rb
@@ -22,5 +22,5 @@ default_action :mount
 
 attribute :name, :kind_of => String, :name_attribute => true
 attribute :server, :kind_of => String, :default => nil, :required => true
-attribute :backup_server, :kind_of => String, :default => nil
+attribute :backup_server, :kind_of => [String, Array], :default => nil
 attribute :mount_point, :kind_of => String, :default => nil, :required => true


### PR DESCRIPTION
This allows for 1 or many backups and should be backwards compatible for people with older installs. 