### PR TITLE
Pull req for biola 1

### DIFF
--- a/attributes/client.rb
+++ b/attributes/client.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-# Gluster volumes to mount
+# Client package
 case node['platform']
 when 'ubuntu'
   default['gluster']['client']['package'] = 'glusterfs-client'
@@ -25,4 +25,5 @@ when 'redhat', 'centos'
   default['gluster']['client']['package'] = 'glusterfs'
 end
 
+# Gluster volumes to mount
 default['gluster']['client']['volumes'] = []

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-default['gluster']['version'] = '3.5'
+default['gluster']['version'] = '3.4'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,4 +17,4 @@
 # limitations under the License.
 #
 
-default['gluster']['version'] = '3.4'
+default['gluster']['version'] = '3.5'

--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -17,12 +17,14 @@
 # limitations under the License.
 #
 
-# Server package
+# Server package and servicename
 case node['platform']
 when 'ubuntu'
   default['gluster']['server']['package'] = 'glusterfs-server'
+  default['gluster']['server']['servicename'] = 'glusterfs-server'
 when 'redhat', 'centos'
   default['gluster']['server']['package'] = 'glusterfs-server'
+  default['gluster']['server']['servicename'] = 'glusterd'
 end
 
 # Package dependencies

--- a/recipes/server_install.rb
+++ b/recipes/server_install.rb
@@ -28,6 +28,6 @@ end
 package node['gluster']['server']['package']
 
 # Make sure the service is started
-service 'glusterd' do
+service node['gluster']['server']['servicename'] do
   action [:enable, :start]
 end

--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -24,7 +24,7 @@ if node['gluster']['server'].attribute?('disks')
     if `fdisk -l 2> /dev/null | grep '/dev/#{d}1'`.empty?
       # Pass commands to fdisk to create a new partition
       bash 'create partition' do
-        code '(echo n; echo p; echo 1; echo; echo; echo w) | fdisk /dev/#{d}'
+        code "(echo n; echo p; echo 1; echo; echo; echo w) | fdisk /dev/#{d}"
         action :run
       end
       


### PR DESCRIPTION
This fixes a quotation-problem in bash-code-snippet where variables weren't properly expanded and also adds a "servicename" which is used to determine what the actual service is called on different dists. For example, in RHEL/CentOS the service is named "glustered". In Debian/Ubuntu it's "glusterfs-server"
(I also reverted my previous default-version-bump to 3.4, that added by mistake).