### PR TITLE
modified order of saving the bricks

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -76,6 +76,8 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
         bricks << "#{node['gluster']['server']['brick_mount_path']}/#{d}1/#{volume_name}"
       end
     end
+    # Save the array of bricks to the node's attributes
+    node.set['gluster']['server']['bricks'] = bricks
   end
 
   # Only continue if the node is the first peer in the array
@@ -169,6 +171,3 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
     end
   end
 end
-
-# Save the array of bricks to the node's attributes
-node.set['gluster']['server']['bricks'] = bricks


### PR DESCRIPTION
modified order of saving the bricks so that they're available later on
when volume-creating parts are run, if installing new machine.
With the "old" location, at the end of the script, nodes would not find
their respective bricks and fail, unless set manually in attributes.