### PR TITLE
retry peering

### DIFF
--- a/attributes/server.rb
+++ b/attributes/server.rb
@@ -43,3 +43,7 @@ default['gluster']['server']['partitions'] = []
 default['gluster']['server']['volumes'] = {}
 # Set by the cookbook once bricks are configured and ready to use
 default['gluster']['server']['bricks'] = []
+
+# Retry delays for attempting peering
+default['gluster']['server']['peer_retries'] = 10
+default['gluster']['server']['peer_retry_delay'] = 3

--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -88,6 +88,8 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
         execute "gluster peer probe #{peer}" do
           action :run
           not_if "egrep '^hostname.+=#{peer}$' /var/lib/glusterd/peers/*"
+          retries node['gluster']['server']['peer_retries']
+          retry_delay node['gluster']['server']['peer_retry_delay']
         end
       end
     end


### PR DESCRIPTION
This patch  retries the attempted peering between the gluster nodes.  This makes deployment more reliable if the first node in the list comes up before the other nodes.
