### PR TITLE
Add peer_names attribute to volumes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Node attributes to specify server volumes to create
 - `node['gluster']['server']['volumes'][VOLUME_NAME]['allowed_hosts']` - an optional array of IP addresses to allow access to the volume
 - `node['gluster']['server']['volumes'][VOLUME_NAME]['disks']` - an optional array of disks to put bricks on (for example, ['sdb', 'sdc']); by default the cookbook will use the first x number of disks, equal to the replica count
 - `node['gluster']['server']['volumes'][VOLUME_NAME]['lvm_volumes']` - an optional array of logical volumes to put bricks on (for example, ['LogVolGlusterBrick1', 'LogVolGlusterBrick2']); by default the cookbook will use the first x number of volumes, equal to the replica count
+- `node['gluster']['server']['volumes'][VOLUME_NAME]['peer_names']` - an optional array of Chef node names for peers used in the volume
 - `node['gluster']['server']['volumes'][VOLUME_NAME]['peers']` - an array of FQDNs for peers used in the volume
 - `node['gluster']['server']['volumes'][VOLUME_NAME]['quota']` - an optional disk quota to set for the volume, such as '10GB'
 - `node['gluster']['server']['volumes'][VOLUME_NAME]['replica_count']` - the number of replicas to create

--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -27,7 +27,7 @@ if node['gluster']['server'].attribute?('disks')
         code "(echo n; echo p; echo 1; echo; echo; echo w) | fdisk /dev/#{d}"
         action :run
       end
-      
+
       # Format the new partition
       execute 'format partition' do
         command "mkfs.xfs -i size=512 /dev/#{d}1"
@@ -97,7 +97,8 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
       # Create a hash of peers and their bricks
       volume_bricks = {}
       brick_count = 0
-      volume_values['peers'].each do |peer|
+      peers = volume_values.attribute?('peer_names') ? volume_values['peer_names'] : volume_values['peers']
+      peers.each do |peer|
         chef_node = Chef::Node.find_or_create(peer)
         if chef_node['gluster']['server'].attribute?('bricks')
           peer_bricks = chef_node['gluster']['server']['bricks'].select { |brick| brick.include? volume_name }
@@ -134,7 +135,7 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
           end
         end
       end
-      
+
       execute "gluster volume create #{volume_name} #{options}" do
         action :run
       end
@@ -167,7 +168,7 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
       execute "gluster volume quota #{volume_name} limit-usage / #{volume_values['quota']}" do
         action :run
         not_if "egrep '^features.limit-usage=/:#{volume_values['quota']}$' /var/lib/glusterd/vols/#{volume_name}/info"
-      end      
+      end
     end
   end
 end


### PR DESCRIPTION
Currently for bricks to be added up correctly, the chef node names must be the same as the FQDN.  This is not always the case.  Adding the `peer_names` attribute allows for the Chef node names to be something other than the FQDN.