### PR TITLE
[trivial] dont shadow bricks

### DIFF
--- a/recipes/server_setup.rb
+++ b/recipes/server_setup.rb
@@ -117,8 +117,8 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
           next
         else
           options = "replica #{volume_values['replica_count']}"
-          volume_bricks.each do |peer, bricks|
-            options << " #{peer}:#{bricks.first}"
+          volume_bricks.each do |peer, vbricks|
+            options << " #{peer}:#{vbricks.first}"
           end
         end
       when 'distributed-replicated'
@@ -129,8 +129,8 @@ node['gluster']['server']['volumes'].each do |volume_name, volume_values|
         else
           options = "replica #{volume_values['replica_count']}"
           (1..volume_values['replica_count']).each do |i|
-            volume_bricks.each do |peer, bricks|
-              options << " #{peer}:#{bricks[i - 1]}"
+            volume_bricks.each do |peer, vbricks|
+              options << " #{peer}:#{vbricks[i - 1]}"
             end
           end
         end


### PR DESCRIPTION
The bricks variable is shadowed a couple times.   The shadowing is ok in this case, but causes the syntax highlighter in vim to complain with every file write.

